### PR TITLE
PipeTextIO interface

### DIFF
--- a/src/ohio/__init__.py
+++ b/src/ohio/__init__.py
@@ -2,7 +2,7 @@
 from .baseio import (IOClosed, StreamTextIOBase)
 from .iterio import IteratorTextIO
 from .csvio import (csv_text, CsvWriterTextIO, CsvDictWriterTextIO)
-from .pipeio import PipeTextIO
+from .pipeio import PipeTextIO, pipe_text
 
 
 __all__ = (
@@ -13,6 +13,7 @@ __all__ = (
     'CsvWriterTextIO',
     'CsvDictWriterTextIO',
     'PipeTextIO',
+    'pipe_text',
 )
 
 


### PR DESCRIPTION
### Changes

* added to `PipeTextIO` interface `buffer_size` and writer invocation `args` & `kwargs`
* `pipe_text` helper

resolves #8