### PR TITLE
recipe: pg_join_queries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ primitives, to help ensure the efficiency, clarity and elegance of
 your code.
 
 For higher-level examples of what Ohio can do for you, see
-`Extensions`_.
+`Extensions`_ and `Recipes`_.
 
 
 Contents
@@ -30,6 +30,10 @@ Contents
       * `Extensions for pandas`_
 
       * `Benchmarking`_
+
+   * `Recipes`_
+
+      * `dbjoin`_
 
 
 csvio
@@ -545,3 +549,86 @@ copy_stringio_to_db
    ``DataFrame`` data are written and encoded to a ``StringIO``, and
    then read by a PostgreSQL database-connected cursor’s ``COPY``
    command.
+
+.. _recipes:
+
+
+Recipes
+=======
+
+Stand-alone modules implementing functionality which depends upon Ohio
+primitives.
+
+
+dbjoin
+------
+
+Join the “COPY” results of arbitrary database queries in Python,
+without unnecessary memory overhead.
+
+This is largely useful to work around databases’ per-query column
+limit.
+
+**ohio.recipe.dbjoin.pg_join_queries(queries, engine, sep=', ',
+end='\n', copy_options=('CSV', 'HEADER'))**
+
+   Join the text-encoded result streams of an arbitrary number of
+   PostgreSQL database queries to work around the database’s per-query
+   column limit.
+
+   Query results are read via PostgreSQL ``COPY``, streamed through
+   ``PipeTextIO``, and joined line-by-line into a singular stream.
+
+   For example, given a set of database queries whose results cannot
+   be combined into a single PostgreSQL query, we might join these
+   queries’ results and write these results to a file-like object:
+
+   ::
+
+      >>> queries = [
+      ...     'SELECT a, b, c FROM a_table',
+      ...     ...
+      ... ]
+
+      >>> with open('results.csv', 'w', newline='') as fdesc:
+      ...     for line in pg_join_queries(queries, engine):
+      ...         fdesc.write(line)
+
+   Or, we might read these results into a single Pandas DataFrame:
+
+   ::
+
+      >>> csv_lines = pg_join_queries(queries, engine)
+      >>> csv_buffer = ohio.IteratorTextIO(csv_lines)
+      >>> df = pandas.read_csv(csv_buffer)
+
+   By default, ``pg_join_queries`` requests CSV-encoded results, with
+   an initial header line indicating the result columns. These
+   options, which are sent directly to the PostgreSQL ``COPY``
+   command, may be controlled via ``copy_options``. For example, to
+   omit the CSV header:
+
+   ::
+
+      >>> pg_join_queries(queries, engine, copy_options=['CSV'])
+
+   Or, to request PostgreSQL’s tab-delimited text format via the
+   syntax of PostgreSQL v9.0+:
+
+   ::
+
+      >>> pg_join_queries(
+      ...     queries,
+      ...     engine,
+      ...     sep='\t',
+      ...     copy_options={'FORMAT': 'TEXT'},
+      ... )
+
+   In the above example, we’ve instructed PostgreSQL to use its
+   ``text`` results encoder, (and we’ve omitted the instruction to
+   include a header).
+
+   **NOTE**: In the last example, we also explicitly specified the
+   separator used in the results’ encoding. This is not passed to the
+   database; rather, it is necessary for ``pg_join_queries`` to
+   properly join queries’ results.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,7 +5,7 @@ Ohio
 
 .. automodule:: ohio
 
-    For higher-level examples of what Ohio can do for you, see `Extensions`_.
+    For higher-level examples of what Ohio can do for you, see `Extensions`_ and `Recipes`_.
 
 
 .. contents::
@@ -140,6 +140,16 @@ Ohio
         ``DataFrame`` data are written and encoded to a ``StringIO``,
         and then read by a PostgreSQL database-connected cursor's
         ``COPY`` command.
+
+
+.. _Recipes:
+
+.. automodule:: ohio.recipe
+
+    .. automodule:: ohio.recipe.dbjoin
+
+        .. autofunction:: ohio.recipe.dbjoin.pg_join_queries
+
 
 .. only:: not noindex
 

--- a/src/ohio/recipe/__init__.py
+++ b/src/ohio/recipe/__init__.py
@@ -1,0 +1,8 @@
+"""
+Recipes
+-------
+
+Stand-alone modules implementing functionality which depends upon Ohio
+primitives.
+
+"""

--- a/src/ohio/recipe/dbjoin.py
+++ b/src/ohio/recipe/dbjoin.py
@@ -1,0 +1,117 @@
+"""
+dbjoin
+------
+
+Join the "COPY" results of arbitrary database queries in Python, without
+unnecessary memory overhead.
+
+This is largely useful to work around databases' per-query column limit.
+
+"""
+import contextlib
+import functools
+
+import ohio
+
+
+JOIN_QUERIES_SEP = ','
+JOIN_QUERIES_END = '\n'
+
+
+def db_join_queries(copy_sqls, engine, sep=JOIN_QUERIES_SEP, end=JOIN_QUERIES_END):
+    """Join the text-encoded result streams of an arbitrary number of
+    database queries to work around the database's per-query column
+    limit.
+
+    **NOTE**: This is a lower-level function, currently utilized only by
+    ``pg_join_queries``. As such, it expects ``copy_sqls`` – statements
+    which appropriately wrap user queries for ``COPY`` – and, it assumes
+    that the database driver exposes method ``copy_expert`` via its
+    cursor. This function is so factored in support of future
+    implementation against additional database systems, and in order to
+    best showcase this Ohio recipe.
+
+    """
+    with contextlib.ExitStack() as stack:
+        raw_conns = iter(engine.raw_connection, None)
+        connections = (stack.enter_context(contextlib.closing(conn))
+                       for conn in raw_conns)
+        cursors = (conn.cursor() for conn in connections)
+
+        writers = (functools.partial(cursor.copy_expert, copy_sql)
+                   for (cursor, copy_sql) in zip(cursors, copy_sqls))
+        pipes = (stack.enter_context(ohio.pipe_text(writer)) for writer in writers)
+
+        for join in zip(*pipes):
+            yield sep.join(line.rstrip('\r\n') for line in join) + end
+
+
+def pg_join_queries(queries, engine,
+                    sep=JOIN_QUERIES_SEP,
+                    end=JOIN_QUERIES_END,
+                    copy_options=('CSV', 'HEADER')):
+    r"""Join the text-encoded result streams of an arbitrary number of
+    PostgreSQL database queries to work around the database's per-query
+    column limit.
+
+    Query results are read via PostgreSQL ``COPY``, streamed through
+    ``PipeTextIO``, and joined line-by-line into a singular stream.
+
+    For example, given a set of database queries whose results cannot be
+    combined into a single PostgreSQL query, we might join these
+    queries' results and write these results to a file-like object::
+
+        >>> queries = [
+        ...     'SELECT a, b, c FROM a_table',
+        ...     ...
+        ... ]
+
+        >>> with open('results.csv', 'w', newline='') as fdesc:
+        ...     for line in pg_join_queries(queries, engine):
+        ...         fdesc.write(line)
+
+    Or, we might read these results into a single Pandas DataFrame::
+
+        >>> csv_lines = pg_join_queries(queries, engine)
+        >>> csv_buffer = ohio.IteratorTextIO(csv_lines)
+        >>> df = pandas.read_csv(csv_buffer)
+
+    By default, ``pg_join_queries`` requests CSV-encoded results, with
+    an initial header line indicating the result columns. These options,
+    which are sent directly to the PostgreSQL ``COPY`` command, may be
+    controlled via ``copy_options``. For example, to omit the CSV
+    header::
+
+        >>> pg_join_queries(queries, engine, copy_options=['CSV'])
+
+    Or, to request PostgreSQL's tab-delimited text format via the syntax
+    of PostgreSQL v9.0+::
+
+        >>> pg_join_queries(
+        ...     queries,
+        ...     engine,
+        ...     sep='\t',
+        ...     copy_options={'FORMAT': 'TEXT'},
+        ... )
+
+    In the above example, we've instructed PostgreSQL to use its
+    ``text`` results encoder, (and we've omitted the instruction to
+    include a header).
+
+    **NOTE**: In the last example, we also explicitly specified the
+    separator used in the results' encoding. This is not passed to the
+    database; rather, it is necessary for ``pg_join_queries`` to
+    properly join queries' results.
+
+    """
+    copy_template = "COPY ({query}) TO STDOUT"
+    if copy_options:
+        if hasattr(copy_options, 'items'):
+            copy_options_v9 = ("{} {}".format(key, value)
+                               for (key, value) in copy_options.items())
+            copy_template += " WITH ({})".format(", ".join(copy_options_v9))
+        else:
+            copy_template += " WITH " + " ".join(copy_options)
+
+    copy_sqls = (copy_template.format(query=query) for query in queries)
+    return db_join_queries(copy_sqls, engine, sep, end)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+import sqlalchemy
+import testing.postgresql
+
+
+@pytest.fixture(name='engine', scope='function')
+def pg_engine():
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = sqlalchemy.create_engine(postgresql.url())
+        yield engine
+        engine.dispose()

--- a/test/ext_test/pandas_test.py
+++ b/test/ext_test/pandas_test.py
@@ -4,8 +4,6 @@ from datetime import datetime
 import numpy
 import pandas
 import pytest
-import sqlalchemy
-import testing.postgresql
 
 import ohio.ext.pandas  # noqa
 
@@ -18,13 +16,6 @@ class TestPandasExt:
     def table_exists(table, engine):
         result = engine.execute(f"select to_regclass('{table}')").scalar()
         return bool(result)
-
-    @pytest.fixture
-    def engine(self):
-        with testing.postgresql.Postgresql() as postgresql:
-            engine = sqlalchemy.create_engine(postgresql.url())
-            yield engine
-            engine.dispose()
 
     @pytest.fixture(name='df')
     def names_df(self):

--- a/test/recipe_test/dbjoin_test.py
+++ b/test/recipe_test/dbjoin_test.py
@@ -1,0 +1,114 @@
+import operator
+from datetime import datetime
+
+import numpy
+import pandas
+import pytest
+
+import ohio
+from ohio.recipe import dbjoin
+
+
+class TestDbJoinRecipe:
+
+    users = (
+        ('Alice', datetime(2019, 1, 2, 13, 0, 0), 302.1),
+        ('Bob', datetime(2018, 10, 20, 8, 7, 10), 2.4),
+        ('Conner', datetime(2019, 2, 20, 11, 53, 0), 30.9),
+        ('Denise', datetime(2019, 3, 2, 9, 26, 22), 3005.102),
+    )
+
+    @pytest.fixture(name='test_engine')
+    def setup_database(self, engine):
+        with engine.connect() as conn:
+            conn.execute(
+                "create table users ("
+                "    id serial,"
+                "    name varchar,"
+                "    last_login timestamp,"
+                "    tetris_high_score double precision"
+                ")"
+            )
+
+            for user in self.users:
+                conn.execute(
+                    "insert into users "
+                    "   (name, last_login, tetris_high_score) "
+                    "values (%s, %s, %s)",
+                    user
+                )
+
+        return engine
+
+    def test_pg_join_queries(self, test_engine):
+        joined_results = dbjoin.pg_join_queries(
+            [
+                'select id, last_login from users',
+                'select name, tetris_high_score from users',
+            ],
+            test_engine,
+        )
+        assert list(joined_results) == [
+            'id,last_login,name,tetris_high_score\n',
+            '1,2019-01-02 13:00:00,Alice,302.1\n',
+            '2,2018-10-20 08:07:10,Bob,2.4\n',
+            '3,2019-02-20 11:53:00,Conner,30.9\n',
+            '4,2019-03-02 09:26:22,Denise,3005.102\n',
+        ]
+
+    def test_pg_join_queries_noheader(self, test_engine):
+        joined_results = dbjoin.pg_join_queries(
+            [
+                'select id, last_login from users',
+                'select name, tetris_high_score from users',
+            ],
+            test_engine,
+            copy_options=['CSV'],
+        )
+        assert list(joined_results) == [
+            '1,2019-01-02 13:00:00,Alice,302.1\n',
+            '2,2018-10-20 08:07:10,Bob,2.4\n',
+            '3,2019-02-20 11:53:00,Conner,30.9\n',
+            '4,2019-03-02 09:26:22,Denise,3005.102\n',
+        ]
+
+    def test_pg_join_queries_text(self, test_engine):
+        joined_results = dbjoin.pg_join_queries(
+            [
+                'select id, last_login from users',
+                'select name, tetris_high_score from users',
+            ],
+            test_engine,
+            sep='\t',
+            copy_options={'FORMAT': 'TEXT'},
+        )
+        assert list(joined_results) == [
+            '1\t2019-01-02 13:00:00\tAlice\t302.1\n',
+            '2\t2018-10-20 08:07:10\tBob\t2.4\n',
+            '3\t2019-02-20 11:53:00\tConner\t30.9\n',
+            '4\t2019-03-02 09:26:22\tDenise\t3005.102\n',
+        ]
+
+    def test_pg_join_queries_dataframe(self, test_engine):
+        joined_results = dbjoin.pg_join_queries(
+            [
+                'select id, last_login from users',
+                'select name, tetris_high_score from users',
+            ],
+            test_engine,
+        )
+        csv_buffer = ohio.IteratorTextIO(joined_results)
+        df = pandas.read_csv(
+            csv_buffer,
+            index_col='id',
+            parse_dates=['last_login'],
+        )
+
+        assert df.index.tolist() == [1, 2, 3, 4]
+        assert df.columns.tolist() == ['last_login', 'name', 'tetris_high_score']
+
+        expected_01_values = list(map(operator.itemgetter(1, 0), self.users))
+        expected_2_values = list(map(operator.itemgetter(2), self.users))
+
+        assert (df[['last_login', 'name']].values == expected_01_values).all()
+        assert numpy.isclose(df['tetris_high_score'].values, expected_2_values).all()


### PR DESCRIPTION
`recipe` sub-package, with helper, `pg_join_queries`, to join results of arbitrary queries, in memory, line-by-line -- to overcome query column limits.