### PR TITLE
csvio: round out lazy csv-encoding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,14 +37,14 @@ csvio
 
 Flexibly encode data to CSV format.
 
-**ohio.csv_text(rows, *writer_args, writer=<built-in function writer>,
-**writer_kwargs)**
+**ohio.encode_csv(rows, *writer_args, writer=<built-in function
+writer>, **writer_kwargs)**
 
    Encode the specified iterable of ``rows`` into CSV text.
 
    Data is encoded to an in-memory ``str``, (rather than to the file
    system), via an internally-managed ``io.StringIO``, (newly
-   constructed for every invocation of ``csv_text``).
+   constructed for every invocation of ``encode_csv``).
 
    For example:
 
@@ -55,7 +55,7 @@ Flexibly encode data to CSV format.
       ...     ('1/2/09 4:53', 'Product1', '1200', 'Visa', 'Betina'),
       ... ]
 
-      >>> encoded_csv = csv_text(data)
+      >>> encoded_csv = encode_csv(data)
 
       >>> encoded_csv[:80]
       '1/2/09 6:17,Product1,1200,Mastercard,carolina\r\n1/2/09 4:53,Product1,1200,Visa,Be'
@@ -85,7 +85,7 @@ Flexibly encode data to CSV format.
       ...      'Name': 'Betina'},
       ... ]
 
-      >>> csv_text(data, writer=csv.DictWriter, fieldnames=header).splitlines(keepends=True)
+      >>> encode_csv(data, writer=csv.DictWriter, fieldnames=header).splitlines(keepends=True)
       ['1/2/09 6:17,Product1,1200,Mastercard,carolina\r\n',
        '1/2/09 4:53,Product1,1200,Visa,Betina\r\n']
 
@@ -98,8 +98,8 @@ Flexibly encode data to CSV format.
 
    Rather than write to the file system, an internal ``io.StringIO``
    buffer is used to store output temporarily, until it is read.
-   (Unlike ``ohio.csv_text``, this buffer is reused across read/write
-   cycles.)
+   (Unlike ``ohio.encode_csv``, this buffer is reused across
+   read/write cycles.)
 
 **class ohio.CsvDictWriterTextIO(*writer_args, **writer_kwargs)**
 
@@ -180,7 +180,7 @@ significantly boost speed, with a minimum of boilerplate.
    some sort of iterator). Its output can then, far more simply and
    easily, be streamed to some input. If your input must be ``read``
    from a file-like object, see ``ohio.IteratorTextIO``. If your
-   output must be CSV-encoded, see ``ohio.csv_text`` and
+   output must be CSV-encoded, see ``ohio.encode_csv`` and
    ``ohio.CsvWriterTextIO``.
 
    ``PipeTextIO`` is suitable for situations where output *must* be
@@ -493,7 +493,7 @@ of 896,677 rows across 83 columns: 1 of these of type timestamp, 51
 integers and 31 floats. The benchmarking package, ``prof``, is
 preserved in `Ohio's repository <https://github.com/dssg/ohio>`_.
 
-.. image:: https://raw.githubusercontent.com/dssg/ohio/0.3.0/doc/img/profile-copy-from-database-to-datafram-1554345457.svg?sanitize=true
+.. image:: https://raw.githubusercontent.com/dssg/ohio/0.3.1/doc/img/profile-copy-from-database-to-datafram-1554345457.svg?sanitize=true
 
 ohio_pg_copy_from_X
    ``pg_copy_from(buffer_size=X)``
@@ -521,7 +521,7 @@ pandas_read_csv_stringio
    ``COPY`` to a ``StringIO``, from which pandas constructs a
    ``DataFrame``.
 
-.. image:: https://raw.githubusercontent.com/dssg/ohio/0.3.0/doc/img/profile-copy-from-dataframe-to-databas-1554320666.svg?sanitize=true
+.. image:: https://raw.githubusercontent.com/dssg/ohio/0.3.1/doc/img/profile-copy-from-dataframe-to-databas-1554320666.svg?sanitize=true
 
 ohio_pg_copy_to_X
    ``pg_copy_to(buffer_size=X)``

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ csvio
 Flexibly encode data to CSV format.
 
 **ohio.encode_csv(rows, *writer_args, writer=<built-in function
-writer>, **writer_kwargs)**
+writer>, write_header=False, **writer_kwargs)**
 
    Encode the specified iterable of ``rows`` into CSV text.
 
@@ -85,21 +85,206 @@ writer>, **writer_kwargs)**
       ...      'Name': 'Betina'},
       ... ]
 
-      >>> encode_csv(data, writer=csv.DictWriter, fieldnames=header).splitlines(keepends=True)
+      >>> encoded_csv = encode_csv(data, writer=csv.DictWriter, fieldnames=header)
+
+      >>> encoded_csv.splitlines(keepends=True)
       ['1/2/09 6:17,Product1,1200,Mastercard,carolina\r\n',
        '1/2/09 4:53,Product1,1200,Visa,Betina\r\n']
 
+   And, for such writers featuring the method ``writeheader``, you may
+   instruct ``encode_csv`` to invoke this, prior to writing ``rows``:
+
+   ::
+
+      >>> encoded_csv = encode_csv(
+      ...     data,
+      ...     writer=csv.DictWriter,
+      ...     fieldnames=header,
+      ...     write_header=True,
+      ... )
+
+      >>> encoded_csv.splitlines(keepends=True)
+      ['Transaction_date,Product,Price,Payment_Type,Name\r\n',
+       '1/2/09 6:17,Product1,1200,Mastercard,carolina\r\n',
+       '1/2/09 4:53,Product1,1200,Visa,Betina\r\n']
+
+**class ohio.CsvTextIO(rows, *writer_args, write_header=False,
+**writer_kwargs)**
+
+   Readable file-like interface encoding specified data as CSV.
+
+   Rows of input data are only consumed and encoded as needed, as
+   ``CsvTextIO`` is read.
+
+   Rather than write to the file system, an internal ``io.StringIO``
+   buffer is used to store output temporarily, until it is read. (Also
+   unlike ``ohio.encode_csv``, this buffer is reused across read/write
+   cycles.)
+
+   For example, we might encode the following data as CSV:
+
+   ::
+
+      >>> data = [
+      ...     ('1/2/09 6:17', 'Product1', '1200', 'Mastercard', 'carolina'),
+      ...     ('1/2/09 4:53', 'Product1', '1200', 'Visa', 'Betina'),
+      ... ]
+
+      >>> csv_buffer = CsvTextIO(data)
+
+   Data may be encoded and retrieved via standard file object methods,
+   such as ``read``, ``readline`` and iteration:
+
+   ::
+
+      >>> csv_buffer.read(15)
+      '1/2/09 6:17,Pro'
+
+      >>> next(csv_buffer)
+      'duct1,1200,Mastercard,carolina\r\n'
+
+      >>> list(csv_buffer)
+      ['1/2/09 4:53,Product1,1200,Visa,Betina\r\n']
+
+      >>> csv_buffer.read()
+      ''
+
+   Note, in the above example, we first read 15 bytes of the encoded
+   CSV, then read the remainder of the line via iteration, (which
+   invokes ``readline``), and then collected the remaining CSV into a
+   list. Finally, we attempted to read the entirety still remaining –
+   which was nothing.
+
+**class ohio.CsvDictTextIO(rows, *writer_args, write_header=False,
+**writer_kwargs)**
+
+   ``CsvTextIO`` which accepts row data in the form of ``dict``.
+
+   Data is passed to ``csv.DictWriter``.
+
+   See also: ``ohio.CsvTextIO``.
+
+**ohio.iter_csv(rows, *writer_args, write_header=False,
+**writer_kwargs)**
+
+   Generate lines of encoded CSV from ``rows`` of data.
+
+   See: ``ohio.CsvWriterTextIO``.
+
+**ohio.iter_dict_csv(rows, *writer_args, write_header=False,
+**writer_kwargs)**
+
+   Generate lines of encoded CSV from ``rows`` of data.
+
+   See: ``ohio.CsvWriterTextIO``.
+
 **class ohio.CsvWriterTextIO(*writer_args, **writer_kwargs)**
 
-   csv.writer-compatible interface to encode CSV & write to memory.
+   csv.writer-compatible interface to iteratively encode CSV in
+   memory.
 
    The writer instance may also be read, to retrieve written CSV, as
-   it is written (iteratively).
+   it is written.
 
    Rather than write to the file system, an internal ``io.StringIO``
    buffer is used to store output temporarily, until it is read.
    (Unlike ``ohio.encode_csv``, this buffer is reused across
    read/write cycles.)
+
+   Features class method ``iter_csv``: a generator to map an input
+   iterable of data ``rows`` to lines of encoded CSV text.
+   (``iter_csv`` differs from ``ohio.encode_csv`` in that it lazily
+   generates lines of CSV, rather than eagerly encoding the entire CSV
+   body.)
+
+   **Note**: If you don’t need to control *how* rows are written, but
+   do want an iterative and/or readable interface to encoded CSV,
+   consider also the more straight-forward ``ohio.CsvTextIO``.
+
+   For example, we may construct ``CsvWriterTextIO`` with the same
+   (optional) arguments as we would ``csv.writer``, (minus the file
+   descriptor):
+
+   ::
+
+      >>> csv_buffer = CsvWriterTextIO(dialect='excel')
+
+   …and write to it, via either ``writerow`` or ``writerows``:
+
+   ::
+
+      >>> csv_buffer.writerows([
+      ...     ('1/2/09 6:17', 'Product1', '1200', 'Mastercard', 'carolina'),
+      ...     ('1/2/09 4:53', 'Product1', '1200', 'Visa', 'Betina'),
+      ... ])
+
+   Written data is then available to be read, via standard file object
+   methods, such as ``read``, ``readline`` and iteration:
+
+   ::
+
+      >>> csv_buffer.read(15)
+      '1/2/09 6:17,Pro'
+
+      >>> list(csv_buffer)
+      ['duct1,1200,Mastercard,carolina\r\n',
+       '1/2/09 4:53,Product1,1200,Visa,Betina\r\n']
+
+   Note, in the above example, we first read 15 bytes of the encoded
+   CSV, and then collected the remaining CSV into a list, through
+   iteration, (which returns its lines, via ``readline``). However,
+   the first line was short by that first 15 bytes.
+
+   That is, reading CSV out of the ``CsvWriterTextIO`` empties that
+   content from its buffer:
+
+   ::
+
+      >>> csv_buffer.read()
+      ''
+
+   We can repopulate our ``CsvWriterTextIO`` buffer by writing to it
+   again:
+
+   ::
+
+      >>> csv_buffer.writerows([
+      ...     ('1/2/09 13:08', 'Product1', '1200', 'Mastercard', 'Federica e Andrea'),
+      ...     ('1/3/09 14:44', 'Product1', '1200', 'Visa', 'Gouya'),
+      ... ])
+
+      >>> encoded_csv = csv_buffer.read()
+
+      >>> encoded_csv[:80]
+      '1/2/09 13:08,Product1,1200,Mastercard,Federica e Andrea\r\n1/3/09 14:44,Product1,1'
+
+      >>> encoded_csv.splitlines(keepends=True)
+      ['1/2/09 13:08,Product1,1200,Mastercard,Federica e Andrea\r\n',
+       '1/3/09 14:44,Product1,1200,Visa,Gouya\r\n']
+
+   Finally, class method ``iter_csv`` can do all this for us,
+   generating lines of encoded CSV as we request them:
+
+   ::
+
+      >>> lines_csv = CsvWriterTextIO.iter_csv([
+      ...     ('Transaction_date', 'Product', 'Price', 'Payment_Type', 'Name'),
+      ...     ('1/2/09 6:17', 'Product1', '1200', 'Mastercard', 'carolina'),
+      ...     ('1/2/09 4:53', 'Product1', '1200', 'Visa', 'Betina'),
+      ...     ('1/2/09 13:08', 'Product1', '1200', 'Mastercard', 'Federica e Andrea'),
+      ...     ('1/3/09 14:44', 'Product1', '1200', 'Visa', 'Gouya'),
+      ... ])
+
+      >>> next(lines_csv)
+      'Transaction_date,Product,Price,Payment_Type,Name\r\n'
+
+      >>> next(lines_csv)
+      '1/2/09 6:17,Product1,1200,Mastercard,carolina\r\n'
+
+      >>> list(lines_csv)
+      ['1/2/09 4:53,Product1,1200,Visa,Betina\r\n',
+       '1/2/09 13:08,Product1,1200,Mastercard,Federica e Andrea\r\n',
+       '1/3/09 14:44,Product1,1200,Visa,Gouya\r\n']
 
 **class ohio.CsvDictWriterTextIO(*writer_args, **writer_kwargs)**
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,7 +13,7 @@ Ohio
 
 .. automodule:: ohio.csvio
 
-.. autofunction:: ohio.csv_text
+.. autofunction:: ohio.encode_csv
 
 .. autoclass:: ohio.CsvWriterTextIO
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,14 @@ Ohio
 
 .. autofunction:: ohio.encode_csv
 
+.. autoclass:: ohio.CsvTextIO
+
+.. autoclass:: ohio.CsvDictTextIO
+
+.. autofunction:: ohio.iter_csv
+
+.. autofunction:: ohio.iter_dict_csv
+
 .. autoclass:: ohio.CsvWriterTextIO
 
 .. autoclass:: ohio.CsvDictWriterTextIO

--- a/src/ohio/__init__.py
+++ b/src/ohio/__init__.py
@@ -7,7 +7,15 @@ primitives, to help ensure the efficiency, clarity and elegance of your code.
 """
 from .baseio import (IOClosed, StreamTextIOBase)
 from .iterio import IteratorTextIO
-from .csvio import (encode_csv, CsvWriterTextIO, CsvDictWriterTextIO)
+from .csvio import (
+    encode_csv,
+    iter_csv,
+    iter_dict_csv,
+    CsvWriterTextIO,
+    CsvDictWriterTextIO,
+    CsvTextIO,
+    CsvDictTextIO,
+)
 from .pipeio import PipeTextIO, pipe_text
 
 
@@ -16,8 +24,12 @@ __all__ = (
     'StreamTextIOBase',
     'IteratorTextIO',
     'encode_csv',
+    'iter_csv',
+    'iter_dict_csv',
     'CsvWriterTextIO',
     'CsvDictWriterTextIO',
+    'CsvTextIO',
+    'CsvDictTextIO',
     'PipeTextIO',
     'pipe_text',
 )

--- a/src/ohio/__init__.py
+++ b/src/ohio/__init__.py
@@ -7,7 +7,7 @@ primitives, to help ensure the efficiency, clarity and elegance of your code.
 """
 from .baseio import (IOClosed, StreamTextIOBase)
 from .iterio import IteratorTextIO
-from .csvio import (csv_text, CsvWriterTextIO, CsvDictWriterTextIO)
+from .csvio import (encode_csv, CsvWriterTextIO, CsvDictWriterTextIO)
 from .pipeio import PipeTextIO, pipe_text
 
 
@@ -15,7 +15,7 @@ __all__ = (
     'IOClosed',
     'StreamTextIOBase',
     'IteratorTextIO',
-    'csv_text',
+    'encode_csv',
     'CsvWriterTextIO',
     'CsvDictWriterTextIO',
     'PipeTextIO',

--- a/src/ohio/csvio.py
+++ b/src/ohio/csvio.py
@@ -11,12 +11,12 @@ import io
 from . import baseio
 
 
-def csv_text(rows, *writer_args, writer=csv.writer, **writer_kwargs):
+def encode_csv(rows, *writer_args, writer=csv.writer, **writer_kwargs):
     r"""Encode the specified iterable of ``rows`` into CSV text.
 
     Data is encoded to an in-memory ``str``, (rather than to the file
     system), via an internally-managed ``io.StringIO``, (newly
-    constructed for every invocation of ``csv_text``).
+    constructed for every invocation of ``encode_csv``).
 
     For example::
 
@@ -25,7 +25,7 @@ def csv_text(rows, *writer_args, writer=csv.writer, **writer_kwargs):
         ...     ('1/2/09 4:53', 'Product1', '1200', 'Visa', 'Betina'),
         ... ]
 
-        >>> encoded_csv = csv_text(data)
+        >>> encoded_csv = encode_csv(data)
 
         >>> encoded_csv[:80]
         '1/2/09 6:17,Product1,1200,Mastercard,carolina\r\n1/2/09 4:53,Product1,1200,Visa,Be'
@@ -52,7 +52,7 @@ def csv_text(rows, *writer_args, writer=csv.writer, **writer_kwargs):
         ...      'Name': 'Betina'},
         ... ]
 
-        >>> csv_text(data, writer=csv.DictWriter, fieldnames=header).splitlines(keepends=True)
+        >>> encode_csv(data, writer=csv.DictWriter, fieldnames=header).splitlines(keepends=True)
         ['1/2/09 6:17,Product1,1200,Mastercard,carolina\r\n',
          '1/2/09 4:53,Product1,1200,Visa,Betina\r\n']
 
@@ -71,7 +71,7 @@ class CsvWriterTextIO(baseio.StreamTextIOBase):
 
     Rather than write to the file system, an internal ``io.StringIO``
     buffer is used to store output temporarily, until it is read.
-    (Unlike ``ohio.csv_text``, this buffer is reused across read/write
+    (Unlike ``ohio.encode_csv``, this buffer is reused across read/write
     cycles.)
 
     """

--- a/src/ohio/csvio.py
+++ b/src/ohio/csvio.py
@@ -11,7 +11,7 @@ import io
 from . import baseio
 
 
-def encode_csv(rows, *writer_args, writer=csv.writer, **writer_kwargs):
+def encode_csv(rows, *writer_args, writer=csv.writer, write_header=False, **writer_kwargs):
     r"""Encode the specified iterable of ``rows`` into CSV text.
 
     Data is encoded to an in-memory ``str``, (rather than to the file
@@ -52,13 +52,32 @@ def encode_csv(rows, *writer_args, writer=csv.writer, **writer_kwargs):
         ...      'Name': 'Betina'},
         ... ]
 
-        >>> encode_csv(data, writer=csv.DictWriter, fieldnames=header).splitlines(keepends=True)
+        >>> encoded_csv = encode_csv(data, writer=csv.DictWriter, fieldnames=header)
+
+        >>> encoded_csv.splitlines(keepends=True)
         ['1/2/09 6:17,Product1,1200,Mastercard,carolina\r\n',
+         '1/2/09 4:53,Product1,1200,Visa,Betina\r\n']
+
+    And, for such writers featuring the method ``writeheader``, you may
+    instruct ``encode_csv`` to invoke this, prior to writing ``rows``::
+
+        >>> encoded_csv = encode_csv(
+        ...     data,
+        ...     writer=csv.DictWriter,
+        ...     fieldnames=header,
+        ...     write_header=True,
+        ... )
+
+        >>> encoded_csv.splitlines(keepends=True)
+        ['Transaction_date,Product,Price,Payment_Type,Name\r\n',
+         '1/2/09 6:17,Product1,1200,Mastercard,carolina\r\n',
          '1/2/09 4:53,Product1,1200,Visa,Betina\r\n']
 
     """
     out = io.StringIO()
     csv_writer = writer(out, *writer_args, **writer_kwargs)
+    if write_header:
+        csv_writer.writeheader()
     csv_writer.writerows(rows)
     return out.getvalue()
 

--- a/src/ohio/csvio.py
+++ b/src/ohio/csvio.py
@@ -82,19 +82,197 @@ def encode_csv(rows, *writer_args, writer=csv.writer, write_header=False, **writ
     return out.getvalue()
 
 
+class CsvTextIO(baseio.StreamTextIOBase):
+    r"""Readable file-like interface encoding specified data as CSV.
+
+    Rows of input data are only consumed and encoded as needed, as
+    ``CsvTextIO`` is read.
+
+    Rather than write to the file system, an internal ``io.StringIO``
+    buffer is used to store output temporarily, until it is read.
+    (Also unlike ``ohio.encode_csv``, this buffer is reused across
+    read/write cycles.)
+
+    For example, we might encode the following data as CSV::
+
+        >>> data = [
+        ...     ('1/2/09 6:17', 'Product1', '1200', 'Mastercard', 'carolina'),
+        ...     ('1/2/09 4:53', 'Product1', '1200', 'Visa', 'Betina'),
+        ... ]
+
+        >>> csv_buffer = CsvTextIO(data)
+
+    Data may be encoded and retrieved via standard file object methods,
+    such as ``read``, ``readline`` and iteration::
+
+        >>> csv_buffer.read(15)
+        '1/2/09 6:17,Pro'
+
+        >>> next(csv_buffer)
+        'duct1,1200,Mastercard,carolina\r\n'
+
+        >>> list(csv_buffer)
+        ['1/2/09 4:53,Product1,1200,Visa,Betina\r\n']
+
+        >>> csv_buffer.read()
+        ''
+
+    Note, in the above example, we first read 15 bytes of the encoded
+    CSV, then read the remainder of the line via iteration, (which
+    invokes ``readline``), and then collected the remaining CSV into a
+    list. Finally, we attempted to read the entirety still remaining –
+    which was nothing.
+
+    """
+    make_writer = csv.writer
+
+    def __init__(self, rows, *writer_args, write_header=False, **writer_kwargs):
+        super().__init__()
+        self.rows = iter(rows)
+        self.must_writeheader = write_header
+        self.outfile = io.StringIO()
+        self.writer = self.make_writer(self.outfile, *writer_args, **writer_kwargs)
+
+    def __next_chunk__(self):
+        if self.must_writeheader:
+            self.writer.writeheader()
+            self.must_writeheader = False
+        else:
+            self.writer.writerow(next(self.rows))
+
+        text = self.outfile.getvalue()
+
+        self.outfile.seek(0)
+        self.outfile.truncate()
+
+        return text
+
+
+class CsvDictTextIO(CsvTextIO):
+    """``CsvTextIO`` which accepts row data in the form of ``dict``.
+
+    Data is passed to ``csv.DictWriter``.
+
+    See also: ``ohio.CsvTextIO``.
+
+    """
+    make_writer = csv.DictWriter
+
+
 class CsvWriterTextIO(baseio.StreamTextIOBase):
-    """csv.writer-compatible interface to encode CSV & write to memory.
+    r"""csv.writer-compatible interface to iteratively encode CSV in
+    memory.
 
     The writer instance may also be read, to retrieve written CSV, as
-    it is written (iteratively).
+    it is written.
 
     Rather than write to the file system, an internal ``io.StringIO``
     buffer is used to store output temporarily, until it is read.
     (Unlike ``ohio.encode_csv``, this buffer is reused across read/write
     cycles.)
 
+    Features class method ``iter_csv``: a generator to map an input
+    iterable of data ``rows`` to lines of encoded CSV text.
+    (``iter_csv`` differs from ``ohio.encode_csv`` in that it lazily
+    generates lines of CSV, rather than eagerly encoding the entire CSV
+    body.)
+
+    **Note**: If you don't need to control *how* rows are written, but
+    do want an iterative and/or readable interface to encoded CSV,
+    consider also the more straight-forward ``ohio.CsvTextIO``.
+
+    For example, we may construct ``CsvWriterTextIO`` with the same
+    (optional) arguments as we would ``csv.writer``, (minus the file
+    descriptor)::
+
+        >>> csv_buffer = CsvWriterTextIO(dialect='excel')
+
+    ...and write to it, via either ``writerow`` or ``writerows``::
+
+        >>> csv_buffer.writerows([
+        ...     ('1/2/09 6:17', 'Product1', '1200', 'Mastercard', 'carolina'),
+        ...     ('1/2/09 4:53', 'Product1', '1200', 'Visa', 'Betina'),
+        ... ])
+
+    Written data is then available to be read, via standard file object
+    methods, such as ``read``, ``readline`` and iteration::
+
+        >>> csv_buffer.read(15)
+        '1/2/09 6:17,Pro'
+
+        >>> list(csv_buffer)
+        ['duct1,1200,Mastercard,carolina\r\n',
+         '1/2/09 4:53,Product1,1200,Visa,Betina\r\n']
+
+    Note, in the above example, we first read 15 bytes of the encoded
+    CSV, and then collected the remaining CSV into a list, through
+    iteration, (which returns its lines, via ``readline``). However, the
+    first line was short by that first 15 bytes.
+
+    That is, reading CSV out of the ``CsvWriterTextIO`` empties that
+    content from its buffer::
+
+        >>> csv_buffer.read()
+        ''
+
+    We can repopulate our ``CsvWriterTextIO`` buffer by writing to it
+    again::
+
+        >>> csv_buffer.writerows([
+        ...     ('1/2/09 13:08', 'Product1', '1200', 'Mastercard', 'Federica e Andrea'),
+        ...     ('1/3/09 14:44', 'Product1', '1200', 'Visa', 'Gouya'),
+        ... ])
+
+        >>> encoded_csv = csv_buffer.read()
+
+        >>> encoded_csv[:80]
+        '1/2/09 13:08,Product1,1200,Mastercard,Federica e Andrea\r\n1/3/09 14:44,Product1,1'
+
+        >>> encoded_csv.splitlines(keepends=True)
+        ['1/2/09 13:08,Product1,1200,Mastercard,Federica e Andrea\r\n',
+         '1/3/09 14:44,Product1,1200,Visa,Gouya\r\n']
+
+    Finally, class method ``iter_csv`` can do all this for us,
+    generating lines of encoded CSV as we request them::
+
+        >>> lines_csv = CsvWriterTextIO.iter_csv([
+        ...     ('Transaction_date', 'Product', 'Price', 'Payment_Type', 'Name'),
+        ...     ('1/2/09 6:17', 'Product1', '1200', 'Mastercard', 'carolina'),
+        ...     ('1/2/09 4:53', 'Product1', '1200', 'Visa', 'Betina'),
+        ...     ('1/2/09 13:08', 'Product1', '1200', 'Mastercard', 'Federica e Andrea'),
+        ...     ('1/3/09 14:44', 'Product1', '1200', 'Visa', 'Gouya'),
+        ... ])
+
+        >>> next(lines_csv)
+        'Transaction_date,Product,Price,Payment_Type,Name\r\n'
+
+        >>> next(lines_csv)
+        '1/2/09 6:17,Product1,1200,Mastercard,carolina\r\n'
+
+        >>> list(lines_csv)
+        ['1/2/09 4:53,Product1,1200,Visa,Betina\r\n',
+         '1/2/09 13:08,Product1,1200,Mastercard,Federica e Andrea\r\n',
+         '1/3/09 14:44,Product1,1200,Visa,Gouya\r\n']
+
     """
     make_writer = csv.writer
+
+    @classmethod
+    def iter_csv(cls, rows, *writer_args, write_header=False, **writer_kwargs):
+        """Generate lines of encoded CSV from ``rows`` of data.
+
+        See: ``ohio.CsvWriterTextIO``.
+
+        """
+        csv_buffer = cls(*writer_args, **writer_kwargs)
+
+        if write_header:
+            csv_buffer.writeheader()
+            yield csv_buffer.read()
+
+        for row in rows:
+            csv_buffer.writerow(row)
+            yield csv_buffer.read()
 
     def __init__(self, *writer_args, **writer_kwargs):
         super().__init__()
@@ -141,3 +319,8 @@ class CsvDictWriterTextIO(CsvWriterTextIO):
 
     def writeheader(self):
         self.writer.writeheader()
+
+
+iter_csv = CsvWriterTextIO.iter_csv
+
+iter_dict_csv = CsvDictWriterTextIO.iter_csv

--- a/src/ohio/pipeio.py
+++ b/src/ohio/pipeio.py
@@ -35,7 +35,7 @@ class PipeTextIO(baseio.StreamTextIOBase):
     some sort of iterator). Its output can then, far more simply and
     easily, be streamed to some input. If your input must be ``read``
     from a file-like object, see ``ohio.IteratorTextIO``. If your output
-    must be CSV-encoded, see ``ohio.csv_text`` and
+    must be CSV-encoded, see ``ohio.encode_csv`` and
     ``ohio.CsvWriterTextIO``.
 
     ``PipeTextIO`` is suitable for situations where output *must* be

--- a/test/csvio_test.py
+++ b/test/csvio_test.py
@@ -15,7 +15,7 @@ class TestCsvText:
         # iterator NOT required; rather, test that iterator ALLOWED:
         csv_input = iter(EXAMPLE_ROWS)
         csv_content = ''.join(ex_csv_stream())
-        assert ohio.csv_text(csv_input) == csv_content
+        assert ohio.encode_csv(csv_input) == csv_content
 
     def test_dictwriter(self):
         csv_input = iter(EXAMPLE_ROWS)
@@ -27,7 +27,7 @@ class TestCsvText:
         next(csv_stream)  # skip header
         csv_content = ''.join(csv_stream)
 
-        assert ohio.csv_text(
+        assert ohio.encode_csv(
             dict_input,
             fieldnames=field_names,
             writer=csv.DictWriter,

--- a/test/csvio_test.py
+++ b/test/csvio_test.py
@@ -75,6 +75,11 @@ class TestCsvWriterTextIO:
         with pytest.raises(io.UnsupportedOperation):
             method(*method_args)
 
+    def test_iter_csv(self):
+        csv_lines = ohio.CsvWriterTextIO.iter_csv(EXAMPLE_ROWS)
+        for (actual_line, expected_line) in zip(csv_lines, ex_csv_stream()):
+            assert actual_line == expected_line
+
 
 class TestCsvDictWriterTextIO:
 
@@ -95,3 +100,63 @@ class TestCsvDictWriterTextIO:
 
         buffer.writerow(dict(zip(EXAMPLE_ROWS[0], EXAMPLE_ROWS[2])))
         assert buffer.read() == next(csv_stream)
+
+    def test_iter_csv(self):
+        fieldnames = EXAMPLE_ROWS[0]
+        rows = (dict(zip(fieldnames, row)) for row in EXAMPLE_ROWS[1:])
+        csv_lines = ohio.CsvDictWriterTextIO.iter_csv(
+            rows,
+            fieldnames=fieldnames,
+            write_header=True,
+        )
+        for (actual_line, expected_line) in zip(csv_lines, ex_csv_stream()):
+            assert actual_line == expected_line
+
+
+class TestCsvTextIO:
+
+    @pytest.fixture
+    def buffer(self):
+        return ohio.CsvTextIO(EXAMPLE_ROWS)
+
+    def test_read(self, buffer):
+        assert buffer.read() == ''.join(ex_csv_stream())
+
+    def test_read_parts(self, buffer):
+        expected = ''.join(ex_csv_stream())
+
+        assert buffer.read(15) == expected[:15]
+
+        assert buffer.read() == expected[15:]
+
+    def test_read_lines(self, buffer):
+        for (actual_line, expected_line) in zip(buffer, ex_csv_stream()):
+            assert actual_line == expected_line
+
+    def test_read_lines_cm(self, buffer):
+        with buffer as buffer1:
+            assert buffer1 is buffer
+
+            for (actual_line, expected_line) in zip(buffer, ex_csv_stream()):
+                assert actual_line == expected_line
+
+            assert buffer.read() == ''
+
+        with pytest.raises(ohio.IOClosed):
+            buffer.read()
+
+
+class TestCsvDictTextIO:
+
+    @pytest.fixture
+    def buffer(self):
+        fieldnames = EXAMPLE_ROWS[0]
+        rows = (dict(zip(fieldnames, row)) for row in EXAMPLE_ROWS[1:])
+        return ohio.CsvDictTextIO(
+            rows,
+            fieldnames=fieldnames,
+            write_header=True,
+        )
+
+    def test_read(self, buffer):
+        assert buffer.read() == ''.join(ex_csv_stream())

--- a/test/csvio_test.py
+++ b/test/csvio_test.py
@@ -9,7 +9,7 @@ import ohio
 from . import ex_csv_stream, EXAMPLE_ROWS
 
 
-class TestCsvText:
+class TestEncodeCsv:
 
     def test_writer(self):
         # iterator NOT required; rather, test that iterator ALLOWED:
@@ -17,20 +17,22 @@ class TestCsvText:
         csv_content = ''.join(ex_csv_stream())
         assert ohio.encode_csv(csv_input) == csv_content
 
-    def test_dictwriter(self):
+    @pytest.mark.parametrize('write_header', (False, True))
+    def test_dictwriter(self, write_header):
         csv_input = iter(EXAMPLE_ROWS)
         field_names = next(csv_input)
         dict_input = (dict(zip(field_names, row)) for row in csv_input)
 
         csv_stream = ex_csv_stream()
-        # note: currently no handling for `writeheader` in this version
-        next(csv_stream)  # skip header
+        if not write_header:
+            next(csv_stream)  # skip header
         csv_content = ''.join(csv_stream)
 
         assert ohio.encode_csv(
             dict_input,
             fieldnames=field_names,
             writer=csv.DictWriter,
+            write_header=write_header,
         ) == csv_content
 
 


### PR DESCRIPTION
``CsvTextIO``, ``CsvWriterTextIO.iter_csv``, *et al.*: simple & lazy ``rows`` → CSV

rounded out ``csvio`` with implementations of *lazily* encoding CSV,
both using existing, customizable ``CsvWriterTextIO`` and via newly
added ``CsvTextIO``.

``CsvTextIO`` is more straight-forward likely the more commonly useful
implementation, featuring the full file-object interface, and requiring
only specification of an iterable of data rows.
    
``CsvWriterTextIO`` remains for more exotic use-cases, with ``iter_csv``
class method now added implementing its basic use, (tho, unlike
``CsvTextIO``, as a simple generator).

Resolves #5.