### PR TITLE
numpy extensions

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -49,6 +49,14 @@ Ohio
 
 .. automodule:: ohio.ext
 
+    .. automodule:: ohio.ext.numpy
+
+        .. autofunction:: ohio.ext.numpy.pg_copy_to_table
+
+        .. autofunction:: ohio.ext.numpy.pg_copy_from_table
+
+        .. autofunction:: ohio.ext.numpy.pg_copy_from_query
+
     .. automodule:: ohio.ext.pandas
 
         .. autoclass:: ohio.ext.pandas.DataFramePgCopyTo

--- a/src/ohio/ext/numpy.py
+++ b/src/ohio/ext/numpy.py
@@ -1,0 +1,98 @@
+import collections
+import contextlib
+import csv
+import functools
+
+import numpy
+import ohio
+
+
+# TODO: test
+def pg_copy_to_table(arr, name, engine, columns=None, fmt=None):
+    target = _sql_table_columns(name, columns)
+    sql = 'COPY {target} FROM STDIN WITH CSV'.format(target=target)
+
+    kwargs = {'fmt': fmt} if fmt is not None else {}
+    writer = functools.partial(_write_csv, arr, **kwargs)
+
+    with ohio.PipeTextIO(writer) as pipe, \
+            contextlib.closing(engine.raw_connection()) as conn:
+        cursor = conn.cursor()
+        cursor.copy_expert(sql, pipe)
+
+
+def _write_csv(arr, buffer, **kwargs):
+    numpy.savetxt(buffer, arr, delimiter=',', **kwargs)
+
+
+def pg_copy_from_query(query, engine, dtype):
+    return _pg_copy_from("({})".format(query), engine, dtype)
+
+
+def pg_copy_from_table(name, engine, dtype, columns=None):
+    source = _sql_table_columns(name, columns)
+    return _pg_copy_from(source, engine, dtype)
+
+
+class NpCsvReader:
+
+    def __init__(self, encoded, squash=False):
+        self.reader = csv.reader(encoded)
+        self.row_count = 0
+        self.row_size = None
+        self.remainder = collections.deque() if squash else None
+
+    @property
+    def shape(self):
+        return (self.row_count, self.row_size)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.remainder:
+            return self.remainder.popleft()
+
+        decoded = next(self.reader)
+
+        if self.row_count == 0:
+            self.row_size = len(decoded)
+
+        self.row_count += 1
+
+        if self.remainder is None:
+            return decoded
+
+        self.remainder.extend(decoded)
+        return self.__next__()
+
+
+def _pg_copy_from(source, engine, dtype):
+    if isinstance(engine, str):
+        raise TypeError("only SQLAlchemy engine supported not 'str'")
+
+    with contextlib.closing(engine.raw_connection()) as conn:
+        cursor = conn.cursor()
+
+        writer = functools.partial(
+            cursor.copy_expert,
+            'COPY {source} TO STDOUT WITH CSV'.format(source=source),
+        )
+
+        with ohio.PipeTextIO(writer) as pipe:
+            reader = NpCsvReader(pipe, squash=True)
+            arr = numpy.fromiter(reader, dtype=dtype)
+
+    arr.shape = reader.shape
+    return arr
+
+
+def _sql_table_columns(table, columns=None):
+    sql = str(table)
+
+    if columns:
+        sql += " ({})".format(
+            ', '.join('"{}"'.format(column) for column in columns),
+        )
+
+    return sql

--- a/src/ohio/ext/numpy.py
+++ b/src/ohio/ext/numpy.py
@@ -1,41 +1,151 @@
+"""
+Extensions for NumPy
+--------------------
+
+This module enables writing NumPy array data to database and populating
+arrays from database via PostgreSQL ``COPY``. The operation is ensured,
+by Ohio, to be memory-efficient.
+
+**NOTE**: This integration is intended for NumPy, and attempts to
+``import numpy``. NumPy must be available (installed) in your
+environment.
+
+"""
 import collections
-import contextlib
 import csv
 import functools
 
 import numpy
+
 import ohio
 
 
-# TODO: test
-def pg_copy_to_table(arr, name, engine, columns=None, fmt=None):
-    target = _sql_table_columns(name, columns)
+# Externals #
+
+def pg_copy_to_table(arr, table_name, connectable, columns=None, fmt=None):
+    """Copy ``array`` to database table via PostgreSQL ``COPY``.
+
+    ``ohio.PipeTextIO`` enables the direct, in-process "piping" of
+    ``array`` CSV into the "standard input" of the PostgreSQL
+    ``COPY`` command, for quick, memory-efficient database persistence,
+    (and without the needless involvement of the local file system).
+
+    For example, given a SQLAlchemy ``connectable`` – either a database
+    connection ``Engine`` or ``Connection`` – and a NumPy ``array``::
+
+        >>> from sqlalchemy import create_engine
+        >>> engine = create_engine('postgresql://')
+
+        >>> arr = numpy.array([1.000102487, 5.982, 2.901, 103.929])
+
+    We may persist this data to an existing table – *e.g.* "data"::
+
+        >>> pg_copy_to_table(arr, 'data', engine, columns=['value'])
+
+    ``pg_copy_to_table`` utilizes ``numpy.savetxt`` and supports its
+    ``fmt`` parameter.
+
+    """
+    target = _sql_table_columns(table_name, columns)
     sql = 'COPY {target} FROM STDIN WITH CSV'.format(target=target)
 
-    kwargs = {'fmt': fmt} if fmt is not None else {}
-    writer = functools.partial(_write_csv, arr, **kwargs)
+    savetxt_kwargs = {'fmt': fmt} if fmt is not None else {}
 
-    with ohio.PipeTextIO(writer) as pipe, \
-            contextlib.closing(engine.raw_connection()) as conn:
-        cursor = conn.cursor()
+    # NOTE: It would be nice to use CsvTextIO in place of PipeTextIO here,
+    # NOTE: and this might provide a minor speed boost, (as with pg_copy_to).
+    #
+    # NOTE: However, while the "meat" of savetxt isn't much, it would also be
+    # NOTE: nice to avoid reimplementing its formatting (fmt) logic, and its
+    # NOTE: handling of array dimensionality -- (at least for now).
+    #
+    # NOTE: That said, there's probably not much to it, and the fmt logic is
+    # NOTE: arguably far less important when the "txt" being "saved" is only an
+    # NOTE: intermediary between the source (array) and the target (database).
+    # NOTE: The fmt is relatively inconsequential so long as the database
+    # NOTE: schema enforces the proper typing and precision.
+    #
+    # NOTE: Rather, fmt matters most to size of the generated CSV; but, at that
+    # NOTE: level, it's just an optimization parameter. (We'd want to keep
+    # NOTE: floats long by default, to avoid losing precision, but allow user
+    # NOTE: to shorten as they like via custom fmt, for smaller CSV payloads.)
+    with ohio.pipe_text(numpy.savetxt,
+                        arr,
+                        delimiter=',',
+                        **savetxt_kwargs) as pipe, \
+            connectable.begin() as tx:
+        # connectable is either an Engine or a Connection,
+        # and as such tx is either a new Connection or the Transaction
+        conn = tx if hasattr(tx, 'execute') else connectable
+        cursor = conn.connection.cursor()
         cursor.copy_expert(sql, pipe)
 
 
-def _write_csv(arr, buffer, **kwargs):
-    numpy.savetxt(buffer, arr, delimiter=',', **kwargs)
+def pg_copy_from_query(query, connectable, dtype):
+    """Construct ``array`` from database ``query`` via PostgreSQL
+    ``COPY``.
+
+    ``ohio.PipeTextIO`` enables the in-process "piping" of the
+    PostgreSQL ``COPY`` command into NumPy's ``fromiter``, for quick,
+    memory-efficient construction of ``array`` from database, (and
+    without the needless involvement of the local file system).
+
+    For example, given a SQLAlchemy ``connectable`` – either a database
+    connection ``Engine`` or ``Connection``::
+
+        >>> from sqlalchemy import create_engine
+        >>> engine = create_engine('postgresql://')
+
+    We may construct a NumPy ``array`` from a given query::
+
+        >>> arr = pg_copy_from_query(
+        ...     'select value0, value1, value3 from data',
+        ...     engine,
+        ...     float,
+        ... )
+
+    """
+    return _pg_copy_from("({})".format(query), connectable, dtype)
 
 
-def pg_copy_from_query(query, engine, dtype):
-    return _pg_copy_from("({})".format(query), engine, dtype)
+def pg_copy_from_table(table_name, connectable, dtype, columns=None):
+    """Construct ``array`` from database table via PostgreSQL ``COPY``.
+
+    ``ohio.PipeTextIO`` enables the in-process "piping" of the
+    PostgreSQL ``COPY`` command into NumPy's ``fromiter``, for quick,
+    memory-efficient construction of ``array`` from database, (and
+    without the needless involvement of the local file system).
+
+    For example, given a SQLAlchemy ``connectable`` – either a database
+    connection ``Engine`` or ``Connection``::
+
+        >>> from sqlalchemy import create_engine
+        >>> engine = create_engine('postgresql://')
+
+    We may construct a NumPy ``array`` from the contents of a specified
+    table::
+
+        >>> arr = pg_copy_from_table(
+        ...     'data',
+        ...     engine,
+        ...     float,
+        ... )
+
+    """
+    source = _sql_table_columns(table_name, columns)
+    return _pg_copy_from(source, connectable, dtype)
 
 
-def pg_copy_from_table(name, engine, dtype, columns=None):
-    source = _sql_table_columns(name, columns)
-    return _pg_copy_from(source, engine, dtype)
-
+# Internals #
 
 class NpCsvReader:
+    """CSV decoder, wrapping ``csv.reader``, which records the ``shape``
+    of the data it decodes.
 
+    When initialized with the ``squash`` flag, iteration of
+    ``NpCsvReader`` returns data cells one-by-one, rather than in rows.
+    (This allows its use to populate NumPy ``array`` via ``fromiter``.)
+
+    """
     def __init__(self, encoded, squash=False):
         self.reader = csv.reader(encoded)
         self.row_count = 0
@@ -67,19 +177,22 @@ class NpCsvReader:
         return self.__next__()
 
 
-def _pg_copy_from(source, engine, dtype):
-    if isinstance(engine, str):
-        raise TypeError("only SQLAlchemy engine supported not 'str'")
-
-    with contextlib.closing(engine.raw_connection()) as conn:
-        cursor = conn.cursor()
+def _pg_copy_from(source, connectable, dtype):
+    """Construct ``array`` from database via PostgreSQL ``COPY``."""
+    with connectable.connect() as conn:
+        # connectable is either an Engine or a Connection.
+        # *Iff* they gave us a Connection, we don't want to close it
+        # for them; so, in either case we want to call connect():
+        # * either we'll create a new Connection from an Engine,
+        # * or we'll create a *branched* Connection (which we can close).
+        cursor = conn.connection.cursor()
 
         writer = functools.partial(
             cursor.copy_expert,
             'COPY {source} TO STDOUT WITH CSV'.format(source=source),
         )
 
-        with ohio.PipeTextIO(writer) as pipe:
+        with ohio.pipe_text(writer) as pipe:
             reader = NpCsvReader(pipe, squash=True)
             arr = numpy.fromiter(reader, dtype=dtype)
 
@@ -88,6 +201,7 @@ def _pg_copy_from(source, engine, dtype):
 
 
 def _sql_table_columns(table, columns=None):
+    """Encode given table and optional columns for use in SQL."""
     sql = str(table)
 
     if columns:

--- a/src/ohio/ext/numpy.py
+++ b/src/ohio/ext/numpy.py
@@ -6,7 +6,7 @@ This module enables writing NumPy array data to database and populating
 arrays from database via PostgreSQL ``COPY``. The operation is ensured,
 by Ohio, to be memory-efficient.
 
-**NOTE**: This integration is intended for NumPy, and attempts to
+**Note**: This integration is intended for NumPy, and attempts to
 ``import numpy``. NumPy must be available (installed) in your
 environment.
 

--- a/src/ohio/ext/pandas.py
+++ b/src/ohio/ext/pandas.py
@@ -47,7 +47,7 @@ class DataFramePgCopyTo:
     Pandas ``DataFrame``::
 
         >>> from sqlalchemy import create_engine
-        >>> engine = create_engine('sqlite://', echo=False)
+        >>> engine = create_engine('postgresql://')
 
         >>> df = pandas.DataFrame({'name' : ['User 1', 'User 2', 'User 3']})
 
@@ -111,7 +111,7 @@ def data_frame_pg_copy_from(sql, engine,
     For example, given a SQLAlchemy database connection engine::
 
         >>> from sqlalchemy import create_engine
-        >>> engine = create_engine('sqlite://', echo=False)
+        >>> engine = create_engine('postgresql://')
 
     We may simply invoke the ``DataFrame``'s Ohio extension method,
     ``pg_copy_from``::

--- a/src/ohio/ext/pandas.py
+++ b/src/ohio/ext/pandas.py
@@ -1,5 +1,5 @@
 """
-Extensions for pandas
+Extensions for Pandas
 ---------------------
 
 This module extends ``pandas.DataFrame`` with methods ``pg_copy_to`` and
@@ -21,7 +21,7 @@ package::
 then in its ``__init__.py``, to ensure that extensions are loaded before
 your code, which uses them, is run.
 
-**NOTE**: These extensions are intended for Pandas, and attempt to
+**Note**: These extensions are intended for Pandas, and attempt to
 ``import pandas``. Pandas must be available (installed) in your
 environment.
 

--- a/test/ext_test/numpy_test.py
+++ b/test/ext_test/numpy_test.py
@@ -1,0 +1,147 @@
+import functools
+
+import numpy as np
+import pytest
+import sqlalchemy
+import testing.postgresql
+
+from ohio.ext import numpy as op
+
+
+# FIXME: use shared once that's merged
+@pytest.fixture
+def engine():
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = sqlalchemy.create_engine(postgresql.url())
+        yield engine
+        engine.dispose()
+
+
+@pytest.fixture(name='test_engine')
+def setup_engine(engine):
+    engine.execute(
+        "create table data ("
+        "    id serial,"
+        "    value0 double precision,"
+        "    value1 double precision,"
+        "    value2 double precision"
+        ")"
+    )
+    return engine
+
+
+def get_connectable(test_engine, use_conn):
+    return test_engine.connect() if use_conn else test_engine
+
+
+@pytest.mark.parametrize('use_conn', (True, False))
+class TestNumpyExtPgCopyTo:
+
+    def test_pg_copy_to_table_1d(self, test_engine, use_conn):
+        arr = np.array([1.000102487, 5.982, 2.901, 103.929])
+
+        op.pg_copy_to_table(
+            arr,
+            'data',
+            get_connectable(test_engine, use_conn),
+            columns=['value0'],
+        )
+
+        persisted = test_engine.execute('select id, value0 from data').fetchall()
+        assert persisted == list(enumerate(arr, 1))
+
+    def test_pg_copy_to_table_2d(self, test_engine, use_conn):
+        arr = np.array([
+            [1.000102487, 5.982, 2.901],
+            [103.929, 0.000102, 7.9],
+            [29.103, 8.12, 2.1000002],
+        ])
+
+        op.pg_copy_to_table(
+            arr,
+            'data',
+            get_connectable(test_engine, use_conn),
+            columns=['value0', 'value1', 'value2'],
+        )
+
+        persisted = test_engine.execute('select * from data').fetchall()
+        assert persisted == [
+            (index,) + tuple(vals) for (index, vals) in enumerate(arr, 1)
+        ]
+
+    def test_pg_copy_to_table_fmt(self, test_engine, use_conn):
+        arr = np.array([
+            [1.000102487, 5.982, 2.901],
+            [103.929, 0.000102, 7.9],
+            [29.103, 8.12, 2.1000002],
+        ])
+
+        op.pg_copy_to_table(
+            arr,
+            'data',
+            get_connectable(test_engine, use_conn),
+            columns=['value0', 'value1', 'value2'],
+            fmt='%1.3f',
+        )
+
+        persisted = test_engine.execute('select * from data').fetchall()
+
+        rounder = functools.partial(round, ndigits=3)
+        expected = [(index,) + tuple(map(rounder, vals))
+                    for (index, vals) in enumerate(arr, 1)]
+
+        assert persisted == expected
+
+
+@pytest.mark.parametrize('use_conn', (True, False))
+class TestNumpyExtPgCopyFrom:
+
+    data = (
+        (1.000102487, 5.982, 2.901),
+        (103.929, 0.000102, 7.9),
+        (29.103, 8.12, 2.1000002),
+    )
+
+    @pytest.fixture(name='test_engine')
+    def setup_engine(self, test_engine):
+        with test_engine.connect() as conn:
+            for vals in self.data:
+                conn.execute(
+                    'insert into data (value0, value1, value2) '
+                    'values (%s, %s, %s)',
+                    vals
+                )
+
+        return test_engine
+
+    def test_pg_copy_from_query(self, test_engine, use_conn):
+        arr = op.pg_copy_from_query(
+            'select * from data',
+            get_connectable(test_engine, use_conn),
+            float,
+        )
+        assert arr.shape == (3, 4)
+        assert arr.tolist() == [
+            [index] + list(vals) for (index, vals) in enumerate(self.data, 1)
+        ]
+
+    def test_pg_copy_from_table(self, test_engine, use_conn):
+        arr = op.pg_copy_from_table(
+            'data',
+            get_connectable(test_engine, use_conn),
+            float,
+        )
+        assert arr.shape == (3, 4)
+        assert arr.tolist() == [
+            [index] + list(vals) for (index, vals) in enumerate(self.data, 1)
+        ]
+
+    def test_pg_copy_from_table_columns(self, test_engine, use_conn):
+        arr = op.pg_copy_from_table(
+            'data',
+            get_connectable(test_engine, use_conn),
+            float,
+            ['value1', 'value2'],
+        )
+        assert arr.shape == (3, 2)
+        assert arr.tolist() == [list(vals[1:]) for vals in self.data]


### PR DESCRIPTION
Featuring `pg_copy_to_table`, `pg_copy_from_query` & `pg_copy_from_table`.

Resolves #19.

In anticipation of #20, these extensions expect *either* an `Engine` *or* a `Connection` – and, as important, they don't use `raw_connection()`, so listeners, *etc.* should be triggered.